### PR TITLE
Fix biPlanes and biBitCount sizes in BMP.tpl

### DIFF
--- a/templates/Images/BMP.tcl
+++ b/templates/Images/BMP.tcl
@@ -19,8 +19,8 @@ section "BITMAPINFOHEADER" {
 	uint32 "biSize"
 	uint32 "biWidth"
 	int32 "biHeight"	; # signed; heights can be negative
-	uint8 "biPlanes"
-	uint8 "biBitCount"
+	uint16 "biPlanes"
+	uint16 "biBitCount"
 	uint32 "biCompression"
 	uint32 "biSizeImage"
 	uint32 "biXPelsPerMeter"


### PR DESCRIPTION
Hi!

I think there was a mistake when `templates/Images/BMP.tcl` was added in https://github.com/HexFiend/HexFiend/pull/171.

The BMP reference documents contained in the template file mention that the `biPlanes` and `biBitCount` are 2-byte wide (aka `WORD` in the old Microsoft topology), and not one-byte wide.