### PR TITLE
Use a fixed width font for TCL errors and use left-aligned text

### DIFF
--- a/app/resources/Base.lproj/BinaryTemplateController.xib
+++ b/app/resources/Base.lproj/BinaryTemplateController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -80,10 +80,10 @@
                     </tableHeaderView>
                 </scrollView>
                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f71-AR-Dtg">
-                    <rect key="frame" x="-2" y="0.0" width="302" height="130"/>
+                    <rect key="frame" x="4" y="0.0" width="287" height="130"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="3tC-5d-kwc">
-                        <font key="font" metaFont="controlContent" size="11"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="3tC-5d-kwc">
+                        <font key="font" size="12" name="Menlo-Regular"/>
                         <color key="textColor" red="0.37603222150259064" green="0.37603222150259064" blue="0.37603222150259064" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/app/resources/Base.lproj/BinaryTemplateController.xib
+++ b/app/resources/Base.lproj/BinaryTemplateController.xib
@@ -83,7 +83,7 @@
                     <rect key="frame" x="4" y="0.0" width="287" height="130"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="3tC-5d-kwc">
-                        <font key="font" size="12" name="Menlo-Regular"/>
+                        <font key="font" size="12" metaFont="fixedUser"/>
                         <color key="textColor" red="0.37603222150259064" green="0.37603222150259064" blue="0.37603222150259064" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
This slightly tweaks the font in the Binary Template view the TCL script encountered an error.

It used to be center-aligned and in the default font. Since most of the error output from TCL is the failed code it's hard to read if it's not left-aligned and monospaced.
It got switched to "user-monospaced-font" and left-aligned.

Before

<img width="1131" alt="Screen Shot 2021-01-03 at 23 13 51" src="https://user-images.githubusercontent.com/178734/103500456-5ad52880-4e19-11eb-8d9a-ded0d802f401.png">

After:

<img width="2252" alt="Screen Shot 2021-01-03 at 23 14 05" src="https://user-images.githubusercontent.com/178734/103500475-6294cd00-4e19-11eb-865f-883d1f3dcf9c.png">
