### PR TITLE
Add `-collapsed` option to the `section` command and a corresponding free-standing command.

### DIFF
--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -250,11 +250,12 @@
     }
     
     HFTemplateNode *node = [templateController evaluateScript:self.selectedFile.path forController:controller error:&errorMessage];
-    
+
     // Restore current directory
     (void)[fm changeCurrentDirectoryPath:currentDir];
     
     [self setRootNode:node error:errorMessage];
+    [self collapseInitiallyCollapsedGroups:templateController.initiallyCollapsed];
     [self updateSelectionColorRange];
 }
 
@@ -293,6 +294,13 @@
         if (node.isGroup && node.value) {
             [outlineView collapseItem:node];
         }
+    }
+}
+
+- (void)collapseInitiallyCollapsedGroups:(NSArray *)initiallyCollapsed {
+    NSOutlineView *outlineView = self.outlineView;
+    for (HFTemplateNode *node in initiallyCollapsed) {
+        [outlineView collapseItem:node];
     }
 }
 

--- a/app/sources/HFTemplateController.h
+++ b/app/sources/HFTemplateController.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (HFTemplateNode *)evaluateScript:(NSString *)path forController:(HFController *)controller error:(NSString *_Nullable*_Nullable)error;
 
 @property NSUInteger anchor;
+@property NSMutableArray *initiallyCollapsed;
 
 @end
 
@@ -68,7 +69,7 @@ typedef NS_ENUM(NSUInteger, HFEndian) {
 - (void)moveTo:(long long)offset;
 - (void)goTo:(unsigned long long)offset;
 
-- (void)beginSectionWithLabel:(NSString *_Nullable)label;
+- (void)beginSectionWithLabel:(NSString *_Nullable)label collapsed:(BOOL)collapsed;
 - (void)endSection;
 
 @property (readonly) HFTemplateNode *currentSection;

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -36,6 +36,7 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     self.position = 0;
     self.root = [[HFTemplateNode alloc] initGroupWithLabel:nil parent:nil];
     self.currentNode = self.root;
+    self.initiallyCollapsed = [[NSMutableArray alloc] init];
     if (error) {
         *error = nil;
     }
@@ -524,11 +525,14 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
     return self.controller.contentsLength;
 }
 
-- (void)beginSectionWithLabel:(NSString *)label {
+- (void)beginSectionWithLabel:(NSString *)label collapsed:(BOOL)collapsed {
     HFTemplateNode *node = [[HFTemplateNode alloc] initGroupWithLabel:label parent:self.currentNode];
     node.range = HFRangeMake(self.anchor + self.position, 0);
     [self.currentNode.children addObject:node];
     self.currentNode = node;
+    if (collapsed) {
+        [self.initiallyCollapsed addObject:node];
+    }
 }
 
 - (void)endSection {

--- a/templates/Reference.md
+++ b/templates/Reference.md
@@ -46,6 +46,14 @@ uint32 -hex "CRC"
 
 Any command that takes a label will create a new entry in the user interface with the label provided and a string representation of the data type. However, this could become a long list of entries. Therefore entries can be grouped via the `section` command.
 
+    section [-collapsed] label [body]
+
+| Parameter  | Description |
+| ------------- | ------------- |
+| -collapsed | Collapse this section when initially presented  |
+| label |  Label to display |
+| body | |
+
 `section` takes a label argument, just like types do. However, no value is associated with the group. To end grouping, use the `endsection` command. Here's an example:
 
 ```tcl
@@ -69,6 +77,13 @@ Sections by default don't have any value. To set a value on a section, use the `
 ```tcl
 sectionvalue "Example Value"
 ```
+
+Sections may be created in the collapsed state by adding the `-collapsed` flag argument
+ahead of the `section` command's other arguments.  If a section should normally be
+presented in an `expanded` mode but during the process of applying a template it becomes
+clear that the current section is too large to initially display, the `sectioncollapse`
+command can be used to mark the section as initially `-collapsed`.
+
 
 ## Endian
 


### PR DESCRIPTION
This option allows templates a greater degree of control over the initial presentation of the structuring tree they create.  In more detail, the additions are:

* A `-collapsed` flag for the `section` command.
* A `sectioncollapse` command which will mark the current section as initially-collapsed.  Example usage:

```tcl
set i 0
while {![eof]} {
    ... build entry/entries for an object, or even a sub-section ...

    # If there are 100 (or more) of these things, collapse the section they are placed in.
    if {[incr i] == 100} {
        sectioncollapse
    }
}
```