### PR TITLE
Use a fixed width font for TCL errors and use left-aligned text

### DIFF
--- a/app/resources/Base.lproj/BinaryTemplateController.xib
+++ b/app/resources/Base.lproj/BinaryTemplateController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -80,10 +80,10 @@
                     </tableHeaderView>
                 </scrollView>
                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f71-AR-Dtg">
-                    <rect key="frame" x="-2" y="0.0" width="302" height="130"/>
+                    <rect key="frame" x="4" y="0.0" width="287" height="130"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="3tC-5d-kwc">
-                        <font key="font" metaFont="controlContent" size="11"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="3tC-5d-kwc">
+                        <font key="font" size="12" name="Menlo-Regular"/>
                         <color key="textColor" red="0.37603222150259064" green="0.37603222150259064" blue="0.37603222150259064" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/app/resources/Base.lproj/BinaryTemplateController.xib
+++ b/app/resources/Base.lproj/BinaryTemplateController.xib
@@ -83,7 +83,7 @@
                     <rect key="frame" x="4" y="0.0" width="287" height="130"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Label" id="3tC-5d-kwc">
-                        <font key="font" size="12" name="Menlo-Regular"/>
+                        <font key="font" metaFont="fixedUser" size="11"/>
                         <color key="textColor" red="0.37603222150259064" green="0.37603222150259064" blue="0.37603222150259064" alpha="0.84999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>


### PR DESCRIPTION
(Sorry, I'm not sure if it's possible to check in my change to the original PR#300.)

This builds atop PR#300 but includes the `metaFont` usage @kainjow was asking about.