### PR TITLE
Adding `sectionname` command

### DIFF
--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -162,28 +162,18 @@
     [self reselectLastTemplate];
 }
 
-- (void)traversePath:(NSString *)dir intoTemplates:(NSMutableArray<HFTemplateFile*> *)templates {
+- (void)loadTemplates:(id __unused)sender {
     NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *dir = self.templatesFolder;
+    NSMutableArray<HFTemplateFile*> *templates = [NSMutableArray array];
     for (NSString *filename in [fm enumeratorAtPath:dir]) {
         if ([filename.pathExtension isEqualToString:@"tcl"]) {
             HFTemplateFile *file = [[HFTemplateFile alloc] init];
             file.path = [dir stringByAppendingPathComponent:filename];
             file.name = [[filename lastPathComponent] stringByDeletingPathExtension];
             [templates addObject:file];
-        } else {
-            NSURL *url = [NSURL fileURLWithPath:[dir stringByAppendingPathComponent:filename]];
-            NSURL *resolved = url.URLByResolvingSymlinksInPath;
-            if (![url isEqual:resolved] && [resolved hasDirectoryPath]) {
-                [self traversePath:resolved.path intoTemplates:templates];
-            }
         }
     }
-}
-
-- (void)loadTemplates:(id __unused)sender {
-    NSString *dir = self.templatesFolder;
-    NSMutableArray<HFTemplateFile*> *templates = [NSMutableArray array];
-    [self traversePath:dir intoTemplates:templates];
     [templates sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES]]];
     [self.templatesPopUp removeAllItems];
     NSMenuItem *noneItem = [[NSMenuItem alloc] initWithTitle:NSLocalizedString(@"None", nil) action:@selector(noTemplate:) keyEquivalent:@""];

--- a/app/sources/HFTclTemplateController.m
+++ b/app/sources/HFTclTemplateController.m
@@ -55,6 +55,7 @@ enum command {
     command_requires,
     command_section,
     command_endsection,
+    command_sectionname,
     command_sectionvalue,
     command_sectioncollapse,
     command_zlib_uncompress,
@@ -109,6 +110,7 @@ DEFINE_COMMAND(end)
 DEFINE_COMMAND(requires)
 DEFINE_COMMAND(section)
 DEFINE_COMMAND(endsection)
+DEFINE_COMMAND(sectionname)
 DEFINE_COMMAND(sectionvalue)
 DEFINE_COMMAND(sectioncollapse)
 DEFINE_COMMAND(zlib_uncompress)
@@ -175,6 +177,7 @@ DEFINE_COMMAND(uint64_bits)
         CMD(requires),
         CMD(section),
         CMD(endsection),
+        CMD(sectionname),
         CMD(sectionvalue),
         CMD(sectioncollapse),
         CMD(zlib_uncompress),
@@ -484,6 +487,15 @@ DEFINE_COMMAND(uint64_bits)
         case command_endsection: {
             CHECK_NO_ARG;
             [self endSection];
+            break;
+        }
+        case command_sectionname: {
+            if (objc != 2) {
+                Tcl_WrongNumArgs(_interp, 1, objv, "value");
+                return TCL_ERROR;
+            }
+            NSString *name = [NSString stringWithUTF8String:Tcl_GetStringFromObj(objv[1], NULL)];
+            self.currentSection.label = name;
             break;
         }
         case command_sectionvalue: {

--- a/app/sources/HFTemplateNode.h
+++ b/app/sources/HFTemplateNode.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithLabel:(NSString *)label value:(NSString *)value;
 - (instancetype)initGroupWithLabel:(NSString *_Nullable)label parent:(HFTemplateNode *_Nullable)parent;
 
-@property (readonly) NSString *label;
+@property (copy) NSString *label;
 @property (copy) NSString *value;
 @property (readonly) BOOL isGroup;
 @property (readonly, weak) HFTemplateNode *parent;


### PR DESCRIPTION
Sometimes when traversing a template, you'll get more information about a section and may want to rename that section. For example, scanning through Photoshop Image Resource Blocks, you can rename the section to reflect the block that you've found in the file (e.g., `sectionname "Print Info"`). Adding a `sectionname` command lets you rename that section. This also leaves room for `sectionvalue` to contain additional information about that section (e.g., the number of settings found in the Print Info block.)