### PR TITLE
Adding include file support in templates, to allow for reusability of common structures

### DIFF
--- a/app/sources/HFBinaryTemplateController.m
+++ b/app/sources/HFBinaryTemplateController.m
@@ -162,6 +162,10 @@
     [self reselectLastTemplate];
 }
 
+- (NSString *)resolvePath:(NSString *)path {
+    return [NSURL fileURLWithPath:path].URLByResolvingSymlinksInPath.path;
+}
+
 - (void)traversePath:(NSString *)dir intoTemplates:(NSMutableArray<HFTemplateFile*> *)templates {
     NSFileManager *fm = [NSFileManager defaultManager];
     for (NSString *filename in [fm enumeratorAtPath:dir]) {
@@ -171,17 +175,21 @@
             file.name = [[filename lastPathComponent] stringByDeletingPathExtension];
             [templates addObject:file];
         } else {
-            NSURL *url = [NSURL fileURLWithPath:[dir stringByAppendingPathComponent:filename]];
-            NSURL *resolved = url.URLByResolvingSymlinksInPath;
-            if (![url isEqual:resolved] && [resolved hasDirectoryPath]) {
-                [self traversePath:resolved.path intoTemplates:templates];
+            NSString* original = [dir stringByAppendingPathComponent:filename];
+            NSString* resolved = [self resolvePath:original];
+            BOOL isDir = NO;
+            if (![original isEqual:resolved] &&
+                [NSFileManager.defaultManager fileExistsAtPath:resolved isDirectory:&isDir] &&
+                isDir) {
+                [self traversePath:resolved intoTemplates:templates];
             }
         }
     }
 }
 
 - (void)loadTemplates:(id __unused)sender {
-    NSString *dir = self.templatesFolder;
+    // We resolve the templatesFolder in case it's a symlink
+    NSString *dir = [self resolvePath:self.templatesFolder];
     NSMutableArray<HFTemplateFile*> *templates = [NSMutableArray array];
     [self traversePath:dir intoTemplates:templates];
     [templates sortUsingDescriptors:@[[[NSSortDescriptor alloc] initWithKey:@"name" ascending:YES]]];
@@ -251,7 +259,8 @@
     NSString *errorMessage = nil;
     HFTclTemplateController *templateController = [[HFTclTemplateController alloc] init];
     templateController.anchor = self.anchorPosition;
-    
+    templateController.templatesFolder = self.templatesFolder;
+
     // Change directory to the templates folder so "source" command can use relative paths
     NSFileManager *fm = NSFileManager.defaultManager;
     NSString *currentDir = fm.currentDirectoryPath;

--- a/app/sources/HFTemplateController.h
+++ b/app/sources/HFTemplateController.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (HFTemplateNode *)evaluateScript:(NSString *)path forController:(HFController *)controller error:(NSString *_Nullable*_Nullable)error;
 
 @property NSUInteger anchor;
+@property NSString *templatesFolder;
 @property NSMutableArray *initiallyCollapsed;
 
 @end

--- a/app/sources/HFTemplateController.m
+++ b/app/sources/HFTemplateController.m
@@ -1,4 +1,4 @@
-//
+ //
 //  HFTemplateController.m
 //  HexFiend_2
 //
@@ -19,6 +19,7 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
 @property (weak) HFTemplateNode *currentNode;
 @property BOOL requireFailed;
 @property NSMutableData *bytesCache;
+@property NSMutableData *cstrCache;
 @property HFRange bytesCacheRange;
 
 @end
@@ -28,6 +29,7 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
 - (instancetype)init {
     self = [super init];
     _bytesCache = [NSMutableData dataWithLength:kMaxCacheSize];
+    _cstrCache = [NSMutableData dataWithLength:kMaxCacheSize];
     return self;
 }
 
@@ -129,12 +131,10 @@ static const unsigned long long kMaxCacheSize = 1024 * 1024;
 }
 
 - (NSString *)readCStringForEncoding:(HFStringEncoding *)encoding forLabel:(NSString *)label {
-    const size_t maxBytes = 4096;
-    unsigned char buf[maxBytes];
-    bzero(buf, sizeof(buf));
+    unsigned char* buf = _cstrCache.mutableBytes;
     BOOL foundNul = 0;
     size_t offset = 0;
-    for (; offset < maxBytes; offset++) {
+    for (; offset < kMaxCacheSize; offset++) {
         if (![self readBytes:buf + offset size:1]) {
             return nil;
         }

--- a/templates/Reference.md
+++ b/templates/Reference.md
@@ -184,3 +184,15 @@ entry "Channel" $channel
 | Command  | Description | Example |
 | ------------- | ------------- | ------------- |
 | zlib_uncompress *data* | Decompress *data* via zlib | `zlib_uncompress $compressed_data` |
+
+## Including Other Templates
+
+It is possible for one template to include another in its evaluation with the `include` command (v2.14.2+). This can be useful to define common commands or template subcomponents once, and reuse them across multiple templates (for example, defining the Exif metadata format, and reusing it across PNG, JPEG, PSD, etc.) The `include` command takes a path relative to the `Templates` folder. If the file cannot be found or evaluation of the file fails, the command will return an error.
+
+### Example
+
+```tcl
+include "Utilities/General.tcl"
+
+# This script can now use commands defined in the above file, like `assert` and `check`
+```


### PR DESCRIPTION
I also updated the Reference.md file showing how `include` can be used.