### PR TITLE
Fix bad offset in FAT.tcl

### DIFF
--- a/templates/FileSystems/FAT.tcl
+++ b/templates/FileSystems/FAT.tcl
@@ -23,7 +23,7 @@ uint32 LargeSectorsCount
 # Extended BIOS Parameter Block
 uint8 DriveNumber
 hex 1 Reserved
-hex 2 ExtendedBootSignature
+hex 1 ExtendedBootSignature
 uint32 SerialNumber
 ascii 11 VolumeLabel
 ascii 8 SystemIdentifier


### PR DESCRIPTION
At offset 0x26 the "Extended Boot Signature" should be for a length of only a single byte, not two. Accounting for two bytes at this position shifts the template to read incorrectly.