### PR TITLE
Improved JPEG template

### DIFF
--- a/templates/Images/JPEG.tcl
+++ b/templates/Images/JPEG.tcl
@@ -1,191 +1,184 @@
 # JPEG Format
 # Author: Simon Jentzsch
+# Author: Foster Brereton
 
 hf_min_version_required 2.15
+
+include "Metadata/Exif.tcl"
+include "Utility/General.tcl"
+
 big_endian
 requires 0 "FF D8 FF"
 
-include "Metadata/Exif.tcl"
-
-proc is x {set x}
-proc secName {value} {
-  return [switch -- $value {
-    216 { is "Start of Image"}
-    224 { is "JFIF"}
-    192 { is "Baseline DCT"}
-    193 { is "Extended sequential DCT"}
-    194 { is "Progressive DCT"}
-    195 { is "Lossless (sequential)"}
-    196 { is "Def Huffman Table"}
-    197 { is "Differential sequential DCT"}
-    198 { is "Differential progressive DCT"}
-    199 { is "Differential lossless (sequential)"}
-    200 { is "JPEG extensions"}
-    201 { is "Extended sequential DCT"}
-    202 { is "Progressive DCT"}
-    203 { is "Lossless (sequential)"}
-    205 { is "Differential sequential DCT"}
-    206 { is "Differential progressive DCT"}
-    207 { is "Differential lossless (sequential)"}
-    204 { is "Def arithmetic Codes"}
-    219 { is "Def Quantization tables"}
-    221 { is "Def Restart Interval"}
-    225 { is "EXIF"}
-    226 { is "App Data"}
-    227 { is "App Data 3"}
-    228 { is "App Data 4"}
-    229 { is "App Data 5"}
-    230 { is "App Data 6"}
-    231 { is "App Data 7"}
-    232 { is "App Data 8"}
-    233 { is "App Data 9"}
-    234 { is "App Data 10"}
-    235 { is "App Data 11"}
-    236 { is "App Data 12"}
-    237 { is "App Data 13"}
-    238 { is "Copyright"}
-    254 { is "Comment"}
-    218 { is "Start of Scan"}
-    217 { is "End of Image"}
-    default {is [format "Tag %X" $value ]}
-  }]
+proc marker_name {value} {
+    [switch -- $value {
+        0xC0 { return "Baseline DCT" }
+        0xC1 { return "Extended sequential DCT, Huffman coding" }
+        0xC2 { return "Progressive DCT, Huffman coding" }
+        0xC3 { return "Lossless (sequential), Huffman coding" }
+        0xC4 { return "Huffman table" }
+        0xC5 { return "Differential sequential DCT" }
+        0xC6 { return "Differential progressive DCT" }
+        0xC7 { return "Differential lossless (sequential)" }
+        0xC8 { return "Reserved for JPEG extensions" }
+        0xC9 { return "Extended sequential DCT, arithmetic coding" }
+        0xCA { return "Progressive DCT, arithmetic coding" }
+        0xCB { return "Lossless (sequential), arithmetic coding" }
+        0xCC { return "Arithmetic coding conditioning" }
+        0xCD { return "Differential sequential DCT" }
+        0xCE { return "Differential progressive DCT" }
+        0xCF { return "Differential lossless (sequential)" }
+        0xD0 { return "Restart with modulo 8 count "0"" }
+        0xD1 { return "Restart with modulo 8 count "1"" }
+        0xD2 { return "Restart with modulo 8 count "2"" }
+        0xD3 { return "Restart with modulo 8 count "3"" }
+        0xD4 { return "Restart with modulo 8 count "4"" }
+        0xD5 { return "Restart with modulo 8 count "5"" }
+        0xD6 { return "Restart with modulo 8 count "6"" }
+        0xD7 { return "Restart with modulo 8 count "7"" }
+        0xD8 { return "Start of image" }
+        0xD9 { return "End of image" }
+        0xDA { return "Start of scan" }
+        0xDB { return "Quantization table" }
+        0xDC { return "Number of lines" }
+        0xDD { return "Restart interval" }
+        0xDE { return "Hierarchical progression" }
+        0xDF { return "Expand reference component" }
+        0xE0 { return "App0" }
+        0xE1 { return "App1" }
+        0xE2 { return "App2" }
+        0xE3 { return "App3" }
+        0xE4 { return "App4" }
+        0xE5 { return "App5" }
+        0xE6 { return "App6" }
+        0xE7 { return "App7" }
+        0xE8 { return "App8" }
+        0xE9 { return "App9" }
+        0xEA { return "App10" }
+        0xEB { return "App11" }
+        0xEC { return "App12" }
+        0xED { return "App13" }
+        0xEE { return "App14" }
+        0xEF { return "App15" }
+        0xFE { return "JPEG Comment Extension" }
+        default { return [format "Marker %X" $value ]}
+    }]
 }
 
-proc do_exif {} {
-    section "EXIF" {
-        ascii 6 "Exif Marker"
-        Exif
-        big_endian
-    }
-}
-
-proc exif {len stype} {
-    if { $len > 6 && $stype == 225 } {
-        set marker [uint32]
-        move -4
-        if { $marker == 1165519206 } {
-            do_exif
-            return 1
-        }
-    }
-    return 0
-}
 proc find_next {} {
-  set st [pos]
-  set last 0
-  set found 0
-  while {![end]} {
-      set b [uint8]
-      if { $last == 255 && $b > 0 } {
-          set found [expr [pos] - $st - 2 ]
-          break
-      }
-      set last $b 
-  }
-  goto $st
-  return $found
+    set st [pos]
+    set last 0
+    set found 0
+    while {![end]} {
+        set b [uint8]
+        if { $last == 255 && $b > 0 } {
+            set found [expr [pos] - $st - 2 ]
+            break
+        }
+        set last $b 
+    }
+    goto $st
+    return $found
 }
 
-proc esect {stype} {
-    set start_section [pos]
-    set dlen [uint16]
-    set marker [exif $dlen $stype]
-
-    if {$stype >207 && $stype < 216} {
-        move -4
-        section "Restart Marker" {
-            uint8 -hex Marker
-            uint8 -hex Counter
+proc marker_app0 {marker_number} {
+    sectionname [marker_name $marker_number]
+    set len [uint16 "Length"]
+    set identifier [cstr "utf8" "Identifier"]
+    set thumb_size 0
+    if {$identifier == "JFIF"} {
+        uint8 "Version (major)"
+        uint8 "Version (minor)"
+        uint8 "Density Unit"
+        uint16 "Width Density"
+        uint16 "Height Density"
+        set tx [uint8 "Width Thumbnail"]
+        set ty [uint8 "Height Thumbnail"]
+        set thumb_size [expr $tx * $ty * 3]
+        if {$thumb_size > 0} {
+            bytes $thumb_size "Thumbnail Data"
         }
-        set dlen 0
-        set marker 1
-    }
-
-    if { $marker == 0 } {
-        set content [expr $dlen - 2]
-        move -2
-        if {[len] < $start_section + $dlen} {
-            entry InvalidLen $dlen
-            set content 1
-        }
-        switch $stype {
-            225 {
-                section Meta {
-                   uint16 Length
-                   ascii $content "Content"
-                }
-            }
-            238 {
-                section Copyright {
-                    uint16 Length
-                    ascii $content "Content"
-                } 
-            }
-            default {
-                section [secName $stype] {
-                   uint16 Length
-                   bytes $content Content
-                }
-            }
+    } elseif {$identifier == "JFXX"} {
+        set tt [uint8 "Thumbnail Type"]
+        if {$len > 3} {
+            set thumb_size [expr $len - 3]
+            bytes $thumb_size "Thumbnail Data"
         }
     }
+    sectionvalue [human_size $thumb_size]
+}
 
-    goto [expr $start_section + $dlen]
-
-    set next 0
-    if {![end]} {
-        set next [uint8]
-        move -1
+proc marker_appN {marker_number} {
+    sectionname [marker_name $marker_number]
+    set len [uint16 "Length"]
+    set identifier [cstr "utf8" "Identifier"]
+    # subtract three for the length size and the string null terminator
+    set data_size [expr $len - [string length $identifier] - 3]
+    if {$data_size > 0} {
+        bytes $data_size "Data"
     }
+    set human_len [human_size $len]
+    sectionvalue "$human_len ($identifier)"
+}
 
-    if {$next != 255} {
-        set ll [find_next]
-        if {$ll>0} {
-            section ImageData {
-                entry Length $ll
-                bytes $ll data
-            }
-        }
+proc marker_nonapp {marker_number} {
+    sectionname [marker_name $marker_number]
+    set len [uint16 "Length"]
+    if {$len > 2} {
+        bytes [expr $len - 2] "Data"
+    }
+    sectionvalue [human_size $len]
+}
+
+proc marker_start_of_scan {marker_number} {
+    sectionname [marker_name $marker_number]
+    # length of SOS, not JPEG stream length
+    set len [uint16 "Length"]
+    set component_count [uint8 "Component count"]
+    set sos_component_size [expr $component_count * 2]
+    if {$sos_component_size > 0} {
+        bytes $sos_component_size "Components"
+    }
+    uint8 "spss"
+    uint8 "spse"
+    uint8 "sabp"
+    set image_data_length [find_next]
+    sectionvalue [human_size $image_data_length]
+    if {$image_data_length > 0} {
+        bytes $image_data_length "Image data"
     }
 }
 
+main_guard {
+    while {![end]} {
+        section "Segment" {
+            set app_marker_1 [hex 1 "App marker 1"]
+            assert { $app_marker_1 == 0xff } "Unexpected App marker 1"
 
-while {![end]} {
-    set tag_start [uint8]
-    set tag_type [uint8]
+            set app_marker_2 [hex 1 "App marker 2"]
 
-    if {$tag_start != 0xff} break 
-
-    switch $tag_type {
-        0 {}
-        216 {}
-        217 {}
-        224 {
-            section "JFIF" {
-            	set len [uint16 "Length"]
-                set jfif_type [ascii 4 "Marker"]
-                move 1
-                if {$jfif_type == "JFIF"} {
-                    hex 2 "Version"
-                    set unit_type [uint8 "Unit Type"]
-                    uint16 "Width Density"
-                    uint16 "Height Density"
-                    set tx [uint8 "Width Thumbnail"]
-                    set ty [uint8 "Height Thumbnail"]
-                    if {$tx > 0} {
-                        bytes [expr $tx * $ty * 3] "Thumbnail Data"
-                    }
-                }
-                if {$jfif_type == "JFXX"} {
-                    set tt [uint8 "Thumbnail Type"]
-                    if {$len > 3} {
-                        bytes [expr $len - 3] "Thumbnail Data"
-                    }
-                }
+            switch $app_marker_2 {
+                0xD8 { sectionname "Start of Image"; sectionvalue "" }
+                0xD9 { sectionname "End of Image"; sectionvalue "" }
+                0xDA { marker_start_of_scan $app_marker_2 }
+                0xE0 { marker_app0 $app_marker_2 }
+                0xE1 { marker_appN $app_marker_2 }
+                0xE2 { marker_appN $app_marker_2 }
+                0xE3 { marker_appN $app_marker_2 }
+                0xE4 { marker_appN $app_marker_2 }
+                0xE5 { marker_appN $app_marker_2 }
+                0xE6 { marker_appN $app_marker_2 }
+                0xE7 { marker_appN $app_marker_2 }
+                0xE8 { marker_appN $app_marker_2 }
+                0xE9 { marker_appN $app_marker_2 }
+                0xEA { marker_appN $app_marker_2 }
+                0xEB { marker_appN $app_marker_2 }
+                0xEC { marker_appN $app_marker_2 }
+                0xED { marker_appN $app_marker_2 }
+                0xEE { marker_appN $app_marker_2 }
+                0xEF { marker_appN $app_marker_2 }
+                default { marker_nonapp $app_marker_2 }
             }
-        }
-        default {
-            esect $tag_type
         }
     }
 }

--- a/templates/Images/JPEG.tcl
+++ b/templates/Images/JPEG.tcl
@@ -66,19 +66,14 @@ proc marker_name {value} {
 }
 
 proc find_next {} {
-    set st [pos]
-    set last 0
-    set found 0
+    set start [pos]
     while {![end]} {
-        set b [uint8]
-        if { $last == 255 && $b > 0 } {
-            set found [expr [pos] - $st - 2 ]
-            break
-        }
-        set last $b 
+        if { [uint8] != 255 } continue
+        if { [uint8] > 0 } break
     }
-    goto $st
-    return $found
+    set result [expr [pos] - $start - 2]
+    goto $start
+    return $result
 }
 
 proc marker_app0 {} {

--- a/templates/Images/JPEG.tcl
+++ b/templates/Images/JPEG.tcl
@@ -81,8 +81,7 @@ proc find_next {} {
     return $found
 }
 
-proc marker_app0 {marker_number} {
-    sectionname [marker_name $marker_number]
+proc marker_app0 {} {
     set len [uint16 "Length"]
     set identifier [cstr "utf8" "Identifier"]
     set thumb_size 0
@@ -108,8 +107,7 @@ proc marker_app0 {marker_number} {
     sectionvalue [human_size $thumb_size]
 }
 
-proc marker_appN {marker_number} {
-    sectionname [marker_name $marker_number]
+proc marker_appN {} {
     set len [uint16 "Length"]
     set identifier [cstr "utf8" "Identifier"]
     # subtract three for the length size and the string null terminator
@@ -121,8 +119,7 @@ proc marker_appN {marker_number} {
     sectionvalue "$human_len ($identifier)"
 }
 
-proc marker_nonapp {marker_number} {
-    sectionname [marker_name $marker_number]
+proc marker_nonapp {} {
     set len [uint16 "Length"]
     if {$len > 2} {
         bytes [expr $len - 2] "Data"
@@ -130,8 +127,7 @@ proc marker_nonapp {marker_number} {
     sectionvalue [human_size $len]
 }
 
-proc marker_start_of_scan {marker_number} {
-    sectionname [marker_name $marker_number]
+proc marker_start_of_scan {} {
     # length of SOS, not JPEG stream length
     set len [uint16 "Length"]
     set component_count [uint8 "Component count"]
@@ -157,27 +153,29 @@ main_guard {
 
             set app_marker_2 [hex 1 "App marker 2"]
 
+            sectionname [marker_name $app_marker_2]
+
             switch $app_marker_2 {
                 0xD8 { sectionname "Start of Image"; sectionvalue "" }
                 0xD9 { sectionname "End of Image"; sectionvalue "" }
-                0xDA { marker_start_of_scan $app_marker_2 }
-                0xE0 { marker_app0 $app_marker_2 }
-                0xE1 { marker_appN $app_marker_2 }
-                0xE2 { marker_appN $app_marker_2 }
-                0xE3 { marker_appN $app_marker_2 }
-                0xE4 { marker_appN $app_marker_2 }
-                0xE5 { marker_appN $app_marker_2 }
-                0xE6 { marker_appN $app_marker_2 }
-                0xE7 { marker_appN $app_marker_2 }
-                0xE8 { marker_appN $app_marker_2 }
-                0xE9 { marker_appN $app_marker_2 }
-                0xEA { marker_appN $app_marker_2 }
-                0xEB { marker_appN $app_marker_2 }
-                0xEC { marker_appN $app_marker_2 }
-                0xED { marker_appN $app_marker_2 }
-                0xEE { marker_appN $app_marker_2 }
-                0xEF { marker_appN $app_marker_2 }
-                default { marker_nonapp $app_marker_2 }
+                0xDA { marker_start_of_scan }
+                0xE0 { marker_app0 }
+                0xE1 { marker_appN }
+                0xE2 { marker_appN }
+                0xE3 { marker_appN }
+                0xE4 { marker_appN }
+                0xE5 { marker_appN }
+                0xE6 { marker_appN }
+                0xE7 { marker_appN }
+                0xE8 { marker_appN }
+                0xE9 { marker_appN }
+                0xEA { marker_appN }
+                0xEB { marker_appN }
+                0xEC { marker_appN }
+                0xED { marker_appN }
+                0xEE { marker_appN }
+                0xEF { marker_appN }
+                default { marker_nonapp }
             }
         }
     }


### PR DESCRIPTION
This improves the JPEG template to convey more information about the segments found within a file, such as AppN marker identifiers and overall segment sizes. It also improves the segment processing logic so `find_next` can only be called in that segment.

<img width="1151" alt="Screen Shot 2022-02-09 at 10 19 50 a" src="https://user-images.githubusercontent.com/1664117/153264788-30846039-d2ff-48a8-9d00-c01fbbb1ad1d.png">
t