### PR TITLE
Add template for ICOs and CURs

### DIFF
--- a/templates/Images/ICO.tcl
+++ b/templates/Images/ICO.tcl
@@ -1,0 +1,37 @@
+little_endian
+requires 0 "00 00"
+section "Header" {
+	uint16 "Reserved"
+	set type [ uint16 ]
+	if { $type == 1 }  {
+		entry "Type" "Icon"
+	} elseif { $type == 2 } {
+		entry "Type" "Cursor"
+	} else {
+		entry "Type" $type
+	}
+	
+	set imagecount [ uint16 "Image count" ]
+}
+for { set i 0 } { $i < $imagecount } { incr i } {
+	section "Image $i" {
+		uint8 "Width"
+		uint8 "Height"
+		uint8 "Color palette size"
+		uint8 "Reserved"
+		if { $type == 1 } {
+			uint16 "Color planes"
+			uint16 "Bits per pixel"
+		} else {
+			uint16 "Hot spot x"
+			uint16 "Hot spot y"
+		}
+		set isize [ uint32 "Image size" ]
+		set ioffset [ uint32 "Image offset" ]
+
+		set p [ pos ]
+		goto $ioffset
+		bytes $isize "Image data"
+		goto $p
+	}
+}

--- a/templates/Images/ICO.tcl
+++ b/templates/Images/ICO.tcl
@@ -1,22 +1,42 @@
 little_endian
 requires 0 "00 00"
+
+# stolen from TIFF.tcl
+proc backwardEntry {label value length} {
+  move -$length
+  entry $label $value $length
+  move $length
+}
+
+
 section "Header" {
 	uint16 "Reserved"
 	set type [ uint16 ]
+
+
 	if { $type == 1 }  {
-		entry "Type" "Icon"
+		backwardEntry "Type" "Icon" 2 
 	} elseif { $type == 2 } {
-		entry "Type" "Cursor"
+		backwardEntry "Type" "Cursor" 2
 	} else {
-		entry "Type" $type
+		backwardEntry "Type" $type 2
 	}
 	
 	set imagecount [ uint16 "Image count" ]
 }
 for { set i 0 } { $i < $imagecount } { incr i } {
 	section "Image $i" {
-		uint8 "Width"
-		uint8 "Height"
+		set w [ uint8 ]
+		if { $w == 0 } {
+			set w 256
+		}
+		backwardEntry "Width" $w 1
+		set h [ uint8 ]
+		if { $h == 0 } {
+			set h 256
+		}
+		backwardEntry "Height" $h 1
+
 		uint8 "Color palette size"
 		uint8 "Reserved"
 		if { $type == 1 } {


### PR DESCRIPTION
This adds a template for viewing the header of ICO and CUR files.
![image](https://user-images.githubusercontent.com/12257112/172511584-899e749a-db2e-40e5-90e4-30e16b2f3660.png)

