### PR TITLE
Fix PSD template empty data read

### DIFF
--- a/templates/Images/PSD.tcl
+++ b/templates/Images/PSD.tcl
@@ -128,8 +128,11 @@ if {$imrs_len > 0} {
 				uint16 "ID"
 				pascalString "Name" 2
 				set data_len [uint32 "Data length"]
-				set data_len_padded [padto2 $data_len]
-				bytes $data_len_padded "Data"
+				if {$data_len_padded > 0} {
+					bytes $data_len_padded "Data"
+				} else {
+					entry "Data" "empty"
+				}
 				set i [incr i]
 			}
 		}
@@ -246,7 +249,12 @@ if {$lars_len > 0} {
 											}
 											ascii 4 "Key"
 											set data_len [uint32 "Length"]
-											bytes [padto2 $data_len] "Data"
+											set data_len_padded [padto2 $data_len]
+											if {$data_len_padded > 0} {
+												bytes $data_len_padded "Data"
+											} else {
+												entry "Data" "empty"
+											}
 										}
 									}
 								}

--- a/templates/Images/PSD.tcl
+++ b/templates/Images/PSD.tcl
@@ -128,6 +128,7 @@ if {$imrs_len > 0} {
 				uint16 "ID"
 				pascalString "Name" 2
 				set data_len [uint32 "Data length"]
+				set data_len_padded [padto2 $data_len]
 				if {$data_len_padded > 0} {
 					bytes $data_len_padded "Data"
 				} else {


### PR DESCRIPTION
some PSD files are generated with empty data sections, especially from Photopea.  This checks for and displays them properly.