### PR TITLE
Add sanity checks which cap BytesPerColumn at 512 to avoid crashes.

### DIFF
--- a/app/sources/BaseDataDocument.m
+++ b/app/sources/BaseDataDocument.m
@@ -1810,6 +1810,7 @@ cancelled:;
     if (byteGrouping) {
         NSInteger value = byteGrouping.integerValue;
         if (value >= 0) {
+            if (value > 512) {value = 512;} // sanity check to ensure BytesPerColumn isn't set significantly higher than expected
             [self setByteGrouping:value];
             [(AppDelegate *)NSApp.delegate buildByteGroupingMenu];
         }

--- a/framework/sources/HFController.h
+++ b/framework/sources/HFController.h
@@ -239,7 +239,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
 @property (readonly) NSMutableArray<HFColorRange*> *colorRanges;
 - (void)colorRangesDidChange; // manually notify of changes to color range individual values
 
-/* Number of bytes used in each column for a text-style representer. */
+/* Number of bytes used in each column for a text-style representer. Currently capped at 512. */
 @property (nonatomic) NSUInteger bytesPerColumn;
 
 /*! @name Edit Mode

--- a/framework/sources/HFController.m
+++ b/framework/sources/HFController.m
@@ -362,6 +362,7 @@ static inline Class preferredByteArrayClass(void) {
 }
 
 - (void)setBytesPerColumn:(NSUInteger)val {
+    if (val > 512) {val = 512;} // sanity check to ensure bytesPerColumn isn't set significantly higher than expected
     if (val != bytesPerColumn) {
         bytesPerColumn = val;
         [self _addPropertyChangeBits:HFControllerBytesPerColumn];


### PR DESCRIPTION
Adds a cap of 512 for BytesPerColumn, in order to avoid having problems similar to issue #395 occur if someone attempts to set it to a very large number; the cap is applied when setting the property of HFController in the framework, and also when getting a new value from the UI in HexFiend (in BaseDataDocument).

I didn't run into a crash at the same value as that user, but it definitely triggered performance and memory issues, and crashes would happen eventually without any limit on what is entered there.

A cap of 512 might be higher than necessary (especially since 256 doesn't even fit on my screen with 9pt text), and in my opinion the utility of dividing up blocks of bytes goes down pretty quickly as the number of bytes in a column goes up. But there might be people out there with higher resolution displays and better eyesight who would want to go with a relatively higher value compared to the options included in the menu?

The cap value of 512 is hardcoded in both places, and mentioned in a comment in the HFController header.