### PR TITLE
WAV template fix: correctly parse files containing the PEAK chunk

### DIFF
--- a/templates/Audio/WAV.tcl
+++ b/templates/Audio/WAV.tcl
@@ -1,4 +1,5 @@
 proc parse_fmt {} {
+    global num_channels
     section "Format Descriptor" {
         sectionvalue "Wave sample format"
         set format [uint16]
@@ -43,6 +44,7 @@ proc parse_fmt {} {
 }
 
 proc parse_peak {} {
+    global num_channels
     section "Channel Peak Descriptor" {
         uint32 "PEAK chunk version"
         uint32 "Timestamp"


### PR DESCRIPTION
The `parse_peak` procedure referenced a variable that was set in another procedure, causing this:
<img width="929" alt="image" src="https://user-images.githubusercontent.com/1272713/230856204-dd652efe-9c93-4f5e-8dcc-65d84d36b10f.png">

Attached a test WAV file containing the PEAK chunk, for testing:
[2ch-48000-64bit-float.wav.zip](https://github.com/HexFiend/HexFiend/files/11188805/2ch-48000-64bit-float.wav.zip)
