### PR TITLE
Improve GZIP template to display XLEN extra subfields

### DIFF
--- a/templates/Archives/GZIP.tcl
+++ b/templates/Archives/GZIP.tcl
@@ -39,8 +39,20 @@ set extra_flags [hex 1 "Extra flags"]
 uint8 "Operating system"
 
 if {$extra_fields} {
-    set xlen [unit16 "XLEN"]
-    bytes $xlen "Extra data"
+    set xlen [uint16]
+    section "Extra fields total length" {
+        sectionvalue $xlen
+
+        set subftotal 0
+        while {$subftotal < $xlen} {
+            section "Subfield" {
+                hex 2 "Subfield ID"
+                set subflen [uint16 "Length"]
+                bytes $subflen "Subfield data"
+            }
+            set subftotal [expr $subftotal + 4 + $subflen]
+        }
+    }
 }
 
 if {$filename} {


### PR DESCRIPTION
The template fails for GZIP files that contain any extra header fields, due to a `unit16` typo.

This PR fixes the typo and improves the template so that the extra subfields are broken out and displayed.