### PR TITLE
Avoid clobbering the status view string with dummy

### DIFF
--- a/framework/sources/HFStatusBarRepresenter.m
+++ b/framework/sources/HFStatusBarRepresenter.m
@@ -64,7 +64,10 @@
     _statusView.font = [NSFont labelFontOfSize:10];
     _statusView.rep = self;
     _statusView.autoresizingMask = NSViewWidthSizable;
-    _statusView.stringValue = [NSString stringWithUTF8String:__FUNCTION__]; // dummy
+    if ([self controller] == nil) {
+        // controllerDidChange already called updateString so avoid clobbering it
+        _statusView.stringValue = [NSString stringWithUTF8String:__FUNCTION__]; // dummy
+    }
     [_statusView sizeToFit];
     NSView *view = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, _statusView.bounds.size.width, _statusView.bounds.size.height + 4)];
     NSRect statusFrame = _statusView.frame;


### PR DESCRIPTION
By the time createView is called, the controller had already been set and controllerDidChange: and already updated the string.

This fixes https://github.com/HexFiend/HexFiend/issues/358