### PR TITLE
Fix segment type in ELF Template

### DIFF
--- a/templates/Executables/ELF.tcl
+++ b/templates/Executables/ELF.tcl
@@ -48,7 +48,7 @@ section "Program header table" {
       uint32 -hex "Segment type"
 
       if {$ei_class > 1} {
-        uint64 -hex "Flags"
+        uint32 -hex "Flags"
         uint64 -hex "Offset"
         uint64 -hex "Virtual address"
         uint64 -hex "Physical address"


### PR DESCRIPTION
In 64-bit ELF's Program Header, p_flags is of type Elf64_Word(4 bytes).
p_type(Segment type) is also Elf64_Word(4 bytes).


```
typedef struct {
        Elf64_Word      p_type;
        Elf64_Word      p_flags;
        Elf64_Off       p_offset;
        Elf64_Addr      p_vaddr;
        Elf64_Addr      p_paddr;
        Elf64_Xword     p_filesz;
        Elf64_Xword     p_memsz;
        Elf64_Xword     p_align;
} Elf64_Phdr;
```

## References
* Linux elf.h
  - https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf.h#L262
* ELF spec
  - https://www.sco.com/developers/gabi/2000-07-17/ch5.pheader.html
  - https://docs.oracle.com/cd/E19683-01/816-1386/chapter6-83432/index.html
* ELF File type
  - https://docs.oracle.com/cd/E19683-01/816-1386/chapter7-6/index.html