### PR TITLE
Fix HexFiend not rendering correctly when building on macOS 14 SDK

### DIFF
--- a/app/sources/DataInspectorScrollView.m
+++ b/app/sources/DataInspectorScrollView.m
@@ -24,7 +24,8 @@
     NSRectFillUsingOperation(NSIntersectionRect(lineRect, clipRect), NSCompositingOperationSourceOver);
 }
 
-- (void)drawRect:(NSRect)rect {
+- (void)drawRect:(NSRect)__unused dirtyRect {
+    NSRect rect = self.bounds;
     if (!HFDarkModeEnabled()) {
         [[NSColor colorWithCalibratedWhite:(CGFloat).91 alpha:1] set];
         NSRectFillUsingOperation(rect, NSCompositingOperationSourceOver);

--- a/app/sources/DiffTextViewContainer.m
+++ b/app/sources/DiffTextViewContainer.m
@@ -141,7 +141,8 @@
     return result;
 }
 
-- (void)drawRect:(NSRect)dirtyRect {
+- (void)drawRect:(NSRect)__unused dirtyRect {
+    NSRect clipRect = self.bounds;
     /* Paranoia */
     if (! leftView || ! rightView) return;
     
@@ -152,7 +153,7 @@
     } else {
         [[NSColor colorWithCalibratedWhite:.64 alpha:1.] set];
     }
-    NSRectFillUsingOperation(dirtyRect, NSCompositingOperationSourceOver);
+    NSRectFillUsingOperation(clipRect, NSCompositingOperationSourceOver);
     
     CGContextRef ctx = HFGraphicsGetCurrentContext();
     CGFloat lineWidth = 1;
@@ -165,8 +166,8 @@
         BOOL drawActive = (window == nil || [window isMainWindow] || [window isKeyWindow]);
         
         CGFloat shadowWidth = 6;
-        HFDrawShadow(ctx, middleFrame, shadowWidth, NSMinXEdge, drawActive, dirtyRect);
-        HFDrawShadow(ctx, middleFrame, shadowWidth, NSMaxXEdge, drawActive, dirtyRect);
+        HFDrawShadow(ctx, middleFrame, shadowWidth, NSMinXEdge, drawActive, clipRect);
+        HFDrawShadow(ctx, middleFrame, shadowWidth, NSMaxXEdge, drawActive, clipRect);
     }
     
     /* Draw the edge line rects */
@@ -179,10 +180,10 @@
     [dividerColor set];
     lineRect.size.width = lineWidth;
     lineRect.origin.x = NSMinX(middleFrame);
-    if (NSIntersectsRect(lineRect, dirtyRect)) NSRectFill(lineRect);
+    if (NSIntersectsRect(lineRect, clipRect)) NSRectFill(lineRect);
     
     lineRect.origin.x = NSMaxX(middleFrame) - lineWidth;
-    if (NSIntersectsRect(lineRect, dirtyRect)) NSRectFill(lineRect);
+    if (NSIntersectsRect(lineRect, clipRect)) NSRectFill(lineRect);
 }
 
 

--- a/app/sources/TextDividerRepresenter.m
+++ b/app/sources/TextDividerRepresenter.m
@@ -19,7 +19,8 @@
 
 @implementation TextDividerRepresenterView : NSView
 
-- (void)drawRect:(NSRect)clip {
+- (void)drawRect:(NSRect)__unused dirtyRect {
+    NSRect clip = self.bounds;
     NSWindow *window = [self window];
     BOOL drawActive = (window == nil || [window isKeyWindow] || [window isMainWindow]);
     CGContextRef ctx = HFGraphicsGetCurrentContext();

--- a/framework/sources/HFLineCountingView.m
+++ b/framework/sources/HFLineCountingView.m
@@ -226,7 +226,8 @@ static const CGFloat kShadowWidth = 6;
     [string drawInRect:textRect withAttributes:textAttributes];
 }
 
-- (void)drawRect:(NSRect)clipRect {
+- (void)drawRect:(NSRect)__unused dirtyRect {
+    NSRect clipRect = self.bounds;
     [self drawGradientWithClip:clipRect];
     [self drawDividerWithClip:clipRect];
     [self drawLineNumbersWithClipSingleStringDrawing];

--- a/framework/sources/HFRepresenterTextView.m
+++ b/framework/sources/HFRepresenterTextView.m
@@ -1706,7 +1706,8 @@ static size_t unionAndCleanLists(CGRect *rectList, __unsafe_unretained id *value
     }
 }
 
-- (void)drawRect:(CGRect)clip {
+- (void)drawRect:(CGRect)__unused directRect {
+    NSRect clip = self.bounds;
     CGContextRef ctx = HFGraphicsGetCurrentContext();
     
     [[self backgroundColorForEmptySpace] set];


### PR DESCRIPTION
AppKit made some changes in Sonoma with how views aren't clipped to view bounds by default: https://developer.apple.com/documentation/appkit/nsview/4236466-clipstobounds

For this change I just grepped all places that were using the rect in drawRect: and replaced it with the view bounds. Alternatively I think you could have overridden clipsToBounds and returned YES.

Without this change:
<img width="1509" alt="Screenshot 2023-09-03 at 4 32 11 PM" src="https://github.com/HexFiend/HexFiend/assets/857267/cd46f0db-54fa-4901-ba29-ab97936ef50b">

You may want to verify each case that was changed here and see if it's fine to use view bounds.
