### PR TITLE
More use of array generics

### DIFF
--- a/framework/sources/HFController.h
+++ b/framework/sources/HFController.h
@@ -6,6 +6,7 @@
 //
 
 #import <HexFiend/HFFrameworkPrefix.h>
+#import <HexFiend/HFFunctions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -153,7 +154,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
 */
 //@{ 
 /// Gets the current array of representers attached to this controller.
-@property (readonly, copy) NSArray *representers;
+@property (readonly, copy) NSArray<HFRepresenter *> *representers;
 
 /// Adds a new representer to this controller.
 - (void)addRepresenter:(HFRepresenter *)representer;
@@ -226,7 +227,7 @@ You create an HFController via <tt>[[HFController alloc] init]</tt>.  After that
  No range extends beyond the contentsLength, with the exception of a single zero-length range at the end.
 
  When setting, the setter MUST obey the above criteria. A zero length range when setting or getting represents the cursor position. */
-@property (nonatomic, copy) NSArray *selectedContentsRanges;
+@property (nonatomic, copy) NSArray<HFRangeWrapper *> *selectedContentsRanges;
 
 /*! Selects the entire contents. */
 - (IBAction)selectAll:(id)sender;

--- a/framework/sources/HFFunctions.h
+++ b/framework/sources/HFFunctions.h
@@ -483,13 +483,13 @@ NSString *HFDescribeByteCountWithPrefixAndSuffix(const char *_Nullable stringPre
 + (HFRangeWrapper *)withRange:(HFRange)range;
 
 /*! Creates an NSArray of HFRangeWrappers for this HFRange. */
-+ (NSArray *)withRanges:(const HFRange *)ranges count:(NSUInteger)count;
++ (NSArray<HFRangeWrapper *> *)withRanges:(const HFRange *)ranges count:(NSUInteger)count;
 
 /*! Given an NSArray of HFRangeWrappers, get all of the HFRanges into a C array. */
-+ (void)getRanges:(HFRange *)ranges fromArray:(NSArray *)array;
++ (void)getRanges:(HFRange *)ranges fromArray:(NSArray<HFRangeWrapper *> *)array;
 
 /*! Given an array of HFRangeWrappers, returns a "cleaned up" array of equivalent ranges.  This new array represents the same indexes, but overlapping ranges will have been merged, and the ranges will be sorted in ascending order. */
-+ (NSArray *)organizeAndMergeRanges:(NSArray *)inputRanges;
++ (NSArray<HFRangeWrapper *> *)organizeAndMergeRanges:(NSArray<HFRangeWrapper *> *)inputRanges;
 
 @end
 

--- a/framework/sources/HFLayoutRepresenter.h
+++ b/framework/sources/HFLayoutRepresenter.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 */
 //@{
 /// Return the array of representers managed by the receiver. */
-@property (readonly, copy) NSArray *representers;
+@property (readonly, copy) NSArray<HFRepresenter *> *representers;
 
 /*! Adds a new representer to the receiver, triggering relayout. */
 - (void)addRepresenter:(HFRepresenter *)representer;

--- a/framework/sources/HFTextRepresenter.h
+++ b/framework/sources/HFTextRepresenter.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*! The per-row background colors. Each row is drawn with the next color in turn, cycling back to the beginning when the array is exhausted.  Any empty space is filled with the first color in the array.  If the array is empty, then the background is drawn with \c clearColor.
  */
-@property (nonatomic, copy) NSArray *rowBackgroundColors;
+@property (nonatomic, copy) NSArray<HFColor *> *rowBackgroundColors;
 
 /*! Whether the text view behaves like a text field (YES) or a text view (NO).  Currently this determines whether it draws a focus ring when it is the first responder.
 */

--- a/framework/sources/HFTextView.h
+++ b/framework/sources/HFTextView.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Sets the arry of background colors for the receiver. The background colors are used in sequence to draw each row. */
 
 /// The array of background colors for the receiver.
-@property (nonatomic, copy) NSArray *backgroundColors;
+@property (nonatomic, copy) NSArray<HFColor *> *backgroundColors;
 
 /// Whether the receiver draws a border.
 @property (nonatomic) BOOL bordered;


### PR DESCRIPTION
Adds a few more uses of array generics to improve type safety. This is particularly helpful when working with HexFiend from Swift.